### PR TITLE
fix: change the cmd command to execute the correct service name builded

### DIFF
--- a/Dockerfile-minitwit
+++ b/Dockerfile-minitwit
@@ -22,4 +22,4 @@ RUN go build -o /minitwit_service
 EXPOSE 8081
 
 # Run
-CMD ["/minitwit_server"]
+CMD ["/minitwit_service"]


### PR DESCRIPTION
- fixes a mistyping of /minitwit_server to /minitwit_service