### PR TITLE
fix: add ssl keys path to proxy container

### DIFF
--- a/remote_files/docker-compose.yml
+++ b/remote_files/docker-compose.yml
@@ -39,7 +39,8 @@ services:
     volumes:
       - ./proxy/nginx/nginx.conf:/etc/nginx/conf.d/default.conf:ro
       - ./proxy/static/:/usr/share/nginx/html:ro
-      - ./proxy/certbot/www/:/var/www/certbot/:ro
+      - ./proxy/certbot/www/:/var/www/certbot:ro
+      - ./proxy/certbot/conf/:/etc/nginx/ssl:ro
     networks:
       - itu-minitwit-network
 


### PR DESCRIPTION
- fix the ssl path inside nginx container